### PR TITLE
Revise: clean-up layout issues

### DIFF
--- a/src/ui/profile_preferences.ui
+++ b/src/ui/profile_preferences.ui
@@ -276,13 +276,13 @@
          </layout>
         </widget>
        </item>
-       <item row="4" column="0" colspan="2">
+       <item row="4" column="0">
         <widget class="QGroupBox" name="groupBox_logOptions">
          <property name="title">
           <string>Log options</string>
          </property>
-         <layout class="QFormLayout" name="formLayout">
-          <item row="0" column="0">
+         <layout class="QGridLayout" name="gridLayout_6" columnstretch="0,1,0">
+          <item row="0" column="0" colspan="3">
            <widget class="QCheckBox" name="mIsToLogInHtml">
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked will cause the date-stamp named log file to be HTML (file extention '.html') which can convey color, font and other formatting information rather than a plain text (file extension '.txt') format.  If changed whilst logging is already in progress it is necessary to stop and restart logging for this setting to take effect in a new log file.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -292,94 +292,89 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
+          <item row="1" column="0" colspan="3">
            <widget class="QCheckBox" name="mIsLoggingTimestamps">
             <property name="text">
              <string>Add timestamps at the beginning of log lines</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="0" colspan="2">
-           <layout class="QGridLayout" name="gridLayout_logNameOptions">
-            <property name="sizeConstraint">
-             <enum>QLayout::SetDefaultConstraint</enum>
+          <item row="2" column="0" alignment="Qt::AlignRight">
+           <widget class="QLabel" name="label_whereToLog">
+            <property name="text">
+             <string>Save log files in:</string>
             </property>
-            <property name="leftMargin">
-             <number>0</number>
+            <property name="buddy">
+             <cstring>pushButton_whereToLog</cstring>
             </property>
-            <property name="spacing">
-             <number>6</number>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QPushButton" name="pushButton_whereToLog">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+              <horstretch>1</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
             </property>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_whereToLog">
-              <property name="text">
-               <string>Save log files in:</string>
-              </property>
-              <property name="buddy">
-               <cstring>pushButton_whereToLog</cstring>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QPushButton" name="pushButton_whereToLog">
-              <property name="maximumSize">
-               <size>
-                <width>458</width>
-                <height>16777215</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="2">
-             <widget class="QPushButton" name="pushButton_resetLogDir">
-              <property name="toolTip">
-               <string>Set the log directory to default so that logs are saved to the profile's 'log' directory.</string>
-              </property>
-              <property name="text">
-               <string>Reset</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_logFileNameFormat">
-              <property name="text">
-               <string>Log format:</string>
-              </property>
-              <property name="buddy">
-               <cstring>comboBox_logFileNameFormat</cstring>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QComboBox" name="comboBox_logFileNameFormat"/>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_logFileName">
-              <property name="text">
-               <string>Log name:</string>
-              </property>
-              <property name="buddy">
-               <cstring>lineEdit_logFileName</cstring>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QLineEdit" name="lineEdit_logFileName"/>
-            </item>
-            <item row="2" column="2" colspan="2">
-              <widget class="QLabel" name="label_logFileNameExtension">
-                <property name="enabled">
-                  <bool>true</bool>
-                </property>
-                <property name="text">
-                  <string>.txt</string>
-                </property>
-                <property name="buddy">
-                  <cstring>lineEdit_logFileName</cstring>
-                </property>
-              </widget>
-            </item>
-           </layout>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QPushButton" name="pushButton_resetLogDir">
+            <property name="toolTip">
+             <string>Set the log directory to default so that logs are saved to the profile's 'log' directory.</string>
+            </property>
+            <property name="text">
+             <string>Reset</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" alignment="Qt::AlignRight">
+           <widget class="QLabel" name="label_logFileNameFormat">
+            <property name="text">
+             <string>Log format:</string>
+            </property>
+            <property name="buddy">
+             <cstring>comboBox_logFileNameFormat</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" colspan="2">
+           <widget class="QComboBox" name="comboBox_logFileNameFormat">
+            <property name="sizeAdjustPolicy">
+             <enum>QComboBox::AdjustToContents</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" alignment="Qt::AlignRight">
+           <widget class="QLabel" name="label_logFileName">
+            <property name="text">
+             <string>Log name:</string>
+            </property>
+            <property name="buddy">
+             <cstring>lineEdit_logFileName</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="lineEdit_logFileName">
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="2">
+           <widget class="QLabel" name="label_logFileNameExtension">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>.txt</string>
+            </property>
+            <property name="buddy">
+             <cstring>lineEdit_logFileName</cstring>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
Adjusts the `/src/ui/profile_preferences.ui` file to fix the layout the logging controls - as I've suggested on the main Mudlet repository's PR https://github.com/Mudlet/Mudlet/pull/1586.

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>